### PR TITLE
Config deprecations for symfony 3.4

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,7 +3,7 @@ services:
   happyr.linkedin:
     class: Happyr\LinkedIn\LinkedIn
     arguments:
-      - %happyr.linkedin.app_id%
-      - %happyr.linkedin.app_secret%
-      - %happyr.linkedin.request_format%
-      - %happyr.linkedin.response_format%
+      - "%happyr.linkedin.app_id%"
+      - "%happyr.linkedin.app_secret%"
+      - "%happyr.linkedin.request_format%"
+      - "%happyr.linkedin.response_format%"


### PR DESCRIPTION
Not quoting the scalar "%happyr.linkedin.app_id%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0